### PR TITLE
Add defnc macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,51 +43,35 @@ I utilize this simple library at my workplace to great extents, and it has reall
 
 It goes without saying that you should have [re-frame](https://github.com/Day8/re-frame) as a project dependency. You may also need to require it in the namespace(s) you use Peanuts. 
 
-There are two ways to use peanut components, `fc` and `defc`.
+The main way to use peanut components is `defnc`. For documentation on the older `defc` and `fc` macros, see [the README here](https://github.com/sansarip/peanuts/tree/7b9718519760c254942c2df2eeb5aa52e4ec2181)
 
-#### fc
-
-The usage for `fc` is simple, but it's a little more verbose than its `defc` counterpart's.
-
-```clojure
-(ns my-ns
-  (:require [peanuts.core :refer-macros [fc]])
-
-(def a 
-  (fc (fn [& {:keys [a b c]}] 
-        [:div a b c])))
-```
-
-#### defc
-
-The usage for `defc` is more concise than `fc`, but may not be as IDE friendly.
+#### defnc
 
 ```clojure
 (ns my-ns 
-  (:require [peanuts.core :refer-macros [defc]])
+  (:require [peanuts.core :refer [defnc]])
 
 ;; Usages of 'a' might be syntax highlighted as your IDE may think it's undefined
-(defc a 
-  (fn [& {:keys [a b c]}]
-    [:div a b c]))
+(defnc a [& {:keys [a b c]}]
+  [:div a b c])
 ```
 
-If you're using Cursive with IntelliJ as your IDE, then you can resolve `defc` as a `def` and be a-ok! 
+If you're using Cursive with IntelliJ as your IDE, then you can resolve `defnc` as a `defn` and be a-ok! 
 See this [little blurb](https://cursive-ide.com/userguide/macros.html) if you wish to do that!
 
 ### Options
 
-Both `fc` and `defc` macros accept an optional options map as a final argument.
+`defnc` accepts an optional options map as a the second argument.
 
 #### Exempting Args
 
 There may be instances where a component expects certain args to _always_ be keywords and wishes them to be exempt from being used as subscriptions. In such cases, the `:exempt` option comes in handy.
 
 ```clojure
-(defc my-component
-  (fn [a & {:keys [b c d}]
+(defnc my-component
+  {:exempt [b c]}
+  [a & {:keys [b c d}]
     [:div a b c d])
-  {:exempt [b c]})
 ```
 
 In the above example, the values of the `b` and `c` parameters will always be exempt from being rebound to subscriptions.
@@ -105,10 +89,10 @@ In the above example, `:some-key` will be used as a regular keyword and will be 
 Sometimes it's nice to only have certain args involved with subs and have the rest be untouched. The `:only` option is there for such cases.
 
 ```clojure
-(defc my-component
-  (fn [a & {:keys [b c d]}]
+(defnc my-component
+  {:only [a c]}
+  [a & {:keys [b c d]}]
     [:div a b c d])
-  {:only [a c]})
 ```
 
 In the example above, only the `a` and `c` args can be rebound to subscriptions. 
@@ -120,11 +104,11 @@ options are defined with conflicting args.
 Sometimes one may want to pass additional arguments to their subscriptions. The `:sub-args` option assists with this use-case.
 
 ```clojure
-(defc my-component
-  (fn [a & {:keys [b c d]}]
-    [:div a b c])
+(defnc my-component
   {:exempt [a]
-   :sub-args {b [a 1 2 3]}})
+   :sub-args {b [a 1 2 3]}}
+  [a & {:keys [b c d]}]
+    [:div a b c])
 ```
 
 In the above example, `b` can be a function or a subscription key. Notice that I'm passing both literals and `a` reference as args for `b`. There are a couple caveats to note here.
@@ -135,22 +119,22 @@ In the above example, `b` can be a function or a subscription key. Notice that I
 Here's an example of caveat #2.
 
 ```clojure
-(defc my-component
-  (fn [a & {:keys [b c d]}]
-    [:div a b c])
+(defnc my-component
   ;; here the value of 'b' will be the original value provided to the component in 'a's subscription args
   ;; and not the value of 'b's subscription
-  {:sub-args {a [b 1 2 3]}})
+  {:sub-args {a [b 1 2 3]}}
+  [a & {:keys [b c d]}]
+    [:div a b c])
 ```
 
 Below are some examples of using a component that contains `sub-args`:
 
 ```clojure
-(defc my-component
-  (fn [id selected?]
-    [:div {:style {:background-color (if selected? :green :white)}} 
-      "✋"])
-  {:sub-args {selected? [id]}})
+(defnc my-component
+  {:sub-args {selected? [id]}}
+  [id selected?]
+  [:div {:style {:background-color (if selected? :green :white)}} 
+    "✋"])
 
 ;; Use a subscription keyword directly
 [my-component 1 ::subs/selected?]
@@ -167,12 +151,12 @@ Below are some examples of using a component that contains `sub-args`:
 As the examples in the previous section show-case, args that are specified in the `sub-args` option - that are functions - will be called. If you want a function to be called without any args passed to it, that's fine too.
 
 ```clojure
-(defc my-component
-  (fn [selected?]
-    [:div {:style {:background-color (if selected? :green :white)}} 
-      "✋"])
+(defnc my-component
   ;; Specifying an empty arg-vector will result in a function being called without any args as one might expect
-  {:sub-args {selected? []}})
+  {:sub-args {selected? []}}
+  [selected?]
+  [:div {:style {:background-color (if selected? :green :white)}} 
+    "✋"])
 
 [my-component 1 (fn [] @(rf/subscribe [::subs/selected?]))]
 ```
@@ -181,18 +165,10 @@ An alternative way to have function arguments be called (dynamically) is with th
 as demonstrated below.
 
 ```clojure
-(defc my-component
-  (fn [selected?]
-    [:div {:style {:background-color (if selected? :green :white)}} 
-      "✋"]))
+(defnc my-component
+  [selected?]
+  [:div {:style {:background-color (if selected? :green :white)}} 
+    "✋"])
 
 [my-component 1 ^:sub-fn (fn [] @(rf/subscribe [::subs/selected?]))]
 ```
-
-## Suggestions
-
-If you know that certain function parameters in your component will always be constant values/non-subscribeable keywords, then go ahead and exempt them all using the `:exempt` option. This will reduce the size of the function that the macros generate.
-
-Furthermore, it won't hurt to tag args you never want to subscribe to with the `^:exempt` metadata.
-
-The `:only` option really comes in handy when wrapping existing components with peanut components.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ I utilize this simple library at my workplace to great extents, and it has reall
 
 ## Usage
 
-[![Image from Gyazo](https://i.gyazo.com/fad16c281607d88bcff4a3a117ce1ccf.gif)](https://gyazo.com/fad16c281607d88bcff4a3a117ce1ccf)
+[![Image from Gyazo](https://i.gyazo.com/541408228e8a9a313b99f5278d59caef.gif)](https://gyazo.com/541408228e8a9a313b99f5278d59caef)
 
 *An example of wrapping an existing Form-1 component*
 

--- a/src/cljc/peanuts/core.cljc
+++ b/src/cljc/peanuts/core.cljc
@@ -107,3 +107,11 @@
    (->component n f (merge opts {:def? true})))
   ([n f]
    `(defc ~n ~f {})))
+
+(defmacro defnc
+  [n opts args & body]
+  (if (vector? opts)
+    (let [body (into [args] body)
+          args opts]
+      `(defnc ~n {} ~args ~@body))
+    (->component n `(fn ~args ~@body) (merge opts {:def? true}))))

--- a/test/cljc/peanuts/core_test.clj
+++ b/test/cljc/peanuts/core_test.clj
@@ -3,7 +3,7 @@
             [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
-            [clojure.test :refer [use-fixtures]]
+            [clojure.test :refer [use-fixtures testing]]
             [peanuts.test-utilities :refer [is=]]))
 
 ;; necessary for macro-expanding to work with `lein test`
@@ -111,7 +111,8 @@
                              bindings (take-nth 2 (if (= (first bindings) 'clojure.core/let)
                                                     (-> bindings (nth 2) second)
                                                     (second bindings)))]
-                         (every? (complement (set bindings)) exempted))))
+                         (testing "Every exempted arg is not included in the let bindings"
+                           (every? (complement (set bindings)) exempted)))))
 
 (defspec test-defc-and-fc-only-specified-params 20
          (prop/for-all [mf defc-fc-form-with-only-opts-gen]
@@ -126,7 +127,8 @@
                              bindings (take-nth 2 (if (= (first bindings) 'clojure.core/let)
                                                     (-> bindings (nth 2) second)
                                                     (second bindings)))]
-                         (every? (set bindings) only))))
+                         (testing "Every specified only-arg is included in the let bindings"
+                           (every? (set bindings) only)))))
 
 (defspec test-defc-and-fc-include-specified-sub-args 20
          (prop/for-all [mf defc-fc-form-with-sub-arg-opts-gen]
@@ -141,7 +143,8 @@
                              binding-map (get-subargs (apply hash-map (if (= (first bindings) 'clojure.core/let)
                                                                         (-> bindings (nth 2) second)
                                                                         (second bindings))))]
-                         (every? (fn [[k v]] (= (get binding-map k) v)) sub-args))))
+                         (testing "Every specified subscription arg is included in the let bindings"
+                           (every? (fn [[k v]] (= (get binding-map k) v)) sub-args)))))
 
 (defspec test-defc-and-fc-include-specified-subfn-args 20
          (prop/for-all [mf defc-fc-form-with-sub-arg-opts-gen]
@@ -156,4 +159,5 @@
                              binding-map (get-subfnargs (apply hash-map (if (= (first bindings) 'clojure.core/let)
                                                                           (-> bindings (nth 2) second)
                                                                           (second bindings))))]
-                         (every? (fn [[k v]] (= (get binding-map k) v)) sub-args))))
+                         (testing "Every specified subscription fn is included in the let bindings"
+                           (every? (fn [[k v]] (= (get binding-map k) v)) sub-args)))))


### PR DESCRIPTION
Introducing the new and improved `defnc` macro which makes peanuts components a little less janky to use.

The new "syntax" is very similar to that of `defn`, e.g.

```clojure
(defnc my-cool-component [arg1 arg2]
  [:div 
    [:div arg1]
    [:div arg2]])

[my-cool-component :arg1-sub :arg2-sub]
```