### PR TITLE
Introduce clj-kondo support

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["../resources/clj-kondo/clj-kondo.exports/peanuts/peanuts"]}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ pom.xml.asc
 /node_modules
 /devcards/src/cljc/peanuts/core.cljc
 /dist
+/.clj-kondo/.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,9 @@ before_install:
   - 'curl -O https://download.clojure.org/install/linux-install-1.10.1.466.sh'
   - 'chmod +x linux-install-1.10.1.466.sh'
   - 'sudo ./linux-install-1.10.1.466.sh'
-script: 'lein test'
+  - 'curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo'
+  - 'chmod +x install-clj-kondo'
+  - './install-clj-kondo'
+script:
+  - 'clj-kondo --lint src'
+  - 'lein test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - 'sudo ./linux-install-1.10.1.466.sh'
   - 'curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo'
   - 'chmod +x install-clj-kondo'
-  - './install-clj-kondo'
+  - 'sudo ./install-clj-kondo'
 script:
   - 'clj-kondo --lint src'
   - 'lein test'

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 [deps.edn](https://clojure.org/reference/deps_and_cli)
 ```clojure
-peanuts/peanuts {:mvn/version "0.7.0"}
+peanuts/peanuts {:mvn/version "0.7.1"}
 ```
 
 [Leiningen](https://github.com/technomancy/leiningen)
 ```clojure
-[peanuts "0.7.0"]
+[peanuts "0.7.1"]
 ```
 
 ## ToC

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject peanuts "0.7.0"
+(defproject peanuts "0.7.1"
   :description "Packing peanuts for decoupling Reagent Form-1 components from Re-frame subscriptions"
   :url "https://github.com/sansarip/peanuts"
   :signing {:gpg-key "pehrans@gmail.com"}

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
                  [org.clojure/test.check "1.0.0"]]
   :repl-options {:init-ns peanuts.core}
   :source-paths []
+  :resource-paths ["resources/clj-kondo"]
   :aliases {"fig:prod"       ["with-profile" "devcards" "run" "-m" "figwheel.main" "-bo" "prod"]
             "fig:dev"        ["with-profile" "devcards" "trampoline" "run" "-m" "figwheel.main" "-b" "dev" "-r"]
             "deploy:clojars" ["with-profile" "peanuts" "deploy" "clojars"]

--- a/resources/clj-kondo/clj-kondo.exports/peanuts/peanuts/config.edn
+++ b/resources/clj-kondo/clj-kondo.exports/peanuts/peanuts/config.edn
@@ -1,0 +1,2 @@
+{:lint-as {peanuts.core/defnc clojure.core/defn
+           peanuts.core/fnc   clojure.core/fn}}

--- a/src/cljc/peanuts/core.cljc
+++ b/src/cljc/peanuts/core.cljc
@@ -166,7 +166,7 @@
               meta-map
               body
               {:def? true}
-              (if doc-str {:doc doc-str})))))
+              (when doc-str {:doc doc-str})))))
 
 (defmacro fnc
   "Returns an fn form.


### PR DESCRIPTION
Should be able to import by adding `peanuts/peanuts` to your `.clj-kondo/config.edn`.

e.g.

```clojure
{:config-paths ["peanuts/peanuts"]}
```

See the [clj-kondo import instructions](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#exporting-and-importing-configuration) for more info!
